### PR TITLE
DS-2498

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
   - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
+  - export flipRegression_BRANCH_NAME=DS-2498
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "
   - rcode+="write.csv(out, file='test_results.csv'); "
   - rcode+="quit(status = !identical(n.fail, 0), save='no');"
   - Rscript tools/travis_run_before_install.R
-  - export flipRegression_BRANCH_NAME=DS-2498
 
 r_packages:
   - devtools

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get -qq update
   - sudo apt-get install -y libgdal-dev libproj-dev python-protobuf libprotoc-dev libprotobuf-dev libv8-dev librsvg2-dev libmpfr-dev
-  - export flipRegression_BRANCH_NAME=DS-2498
   - rcode="tfile <- tempfile(); capture.output(res<-devtools::test(), file = tfile); out <- readLines(tfile); cat(out, sep = '\n'); "
   - rcode+="n.fail <- as.numeric(sub('Failed:[[:space:]]', '', out[grep('Failed:[[:space:]]', out)])); "
   - rcode+="res <- as.data.frame(res); out <- data.frame(file = unlist(res[['file']]), warning = unlist(res[['warning']])); "

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - rcode+="write.csv(out, file='test_results.csv'); "
   - rcode+="quit(status = !identical(n.fail, 0), save='no');"
   - Rscript tools/travis_run_before_install.R
+  - export flipRegression_BRANCH_NAME=DS-2498
 
 r_packages:
   - devtools

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipRegressionTests
 Type: Package
 Title: Tests for flipRegression
-Version: 1.0.0
+Version: 1.0.1
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Additional tests for the flipRegression package.
@@ -12,6 +12,9 @@ Imports:
 Suggests:
     testthat,
     flipExampleData,
+    car,
+    survey
 Remotes:
     Displayr/flipRegression
-RoxygenNote: 6.0.1
+RoxygenNote: 7.0.2
+Encoding: UTF-8

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -45,12 +45,14 @@ for(missing in c("Multiple imputation", "Imputation (replace missing values with
           # Filter
           z <- suppressWarnings(Regression(Overall ~ Fees + Interest + Phone + Branch + Online + ATM, missing = missing, data = bank, subset = sb,  weights = NULL, type = type))
           expect_error(print(Anova(z)), NA)
+          # Weighted Ordered Logit error check
+          anova.error <- if (type != "Ordered Logit") NA else "^'Anova' can not be computed for a 'Ordered Logit' model with weights"
           # weight,
           z <- suppressWarnings(Regression(Overall ~ Fees + Interest + Phone + Branch + Online + ATM, missing = missing, data = bank, subset = TRUE,  weights = wgt, type = type))
-          expect_error(print(suppressWarnings(Anova(z))), NA)
+          expect_error(print(suppressWarnings(Anova(z))), anova.error)
           # weight, filter
           z <- suppressWarnings(Regression(Overall ~ Fees + Interest + Phone + Branch + Online + ATM, missing = missing, data = bank, subset = sb,  weights = wgt, type = type))
-          expect_error(print(suppressWarnings(Anova(z))), NA)
+          expect_error(print(suppressWarnings(Anova(z))), anova.error)
       })
 
 #### REDUCE DATA SIZE FOR TESTS WITHOUT NUMERICAL EQUALITY ###


### PR DESCRIPTION
When DS-2498 is pulled into master for flipRegression, there will be errors in flipRegressionTest since the svyolr Regression outputs (weighted ordered regression) no longer have an Anova method. This branch updates the tests to expect an error and give the user an informative message.